### PR TITLE
Setting for websocket port + default HTTP_PORT to 80

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 	<script type="text/javascript" src="config.js"></script>
 	
 	<link rel="stylesheet" href="dist/css/bootstrap.min.css">
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 	<link rel="stylesheet" href="dist/css/AdminLTE.min.css">
 	<link rel="stylesheet" href="dist/css/skins/_all-skins.min.css">
 	

--- a/server/server-config.example.js
+++ b/server/server-config.example.js
@@ -2,6 +2,9 @@
 module.exports = {
 	// Port for HTTP server the tablets will connect to
 	http_port : 80,
+
+	// Websocket Port that the website connects to, needs to be the same as in config.js
+	ws_port : 8082,
 	
 	// IP and port for the Martin MxManager Telnet Server
 	mxmanager_ip : "127.0.0.1",

--- a/server/server-config.example.js
+++ b/server/server-config.example.js
@@ -1,7 +1,7 @@
 // Server Configuration
 module.exports = {
 	// Port for HTTP server the tablets will connect to
-	http_port : 8083,
+	http_port : 80,
 	
 	// IP and port for the Martin MxManager Telnet Server
 	mxmanager_ip : "127.0.0.1",

--- a/server/server.js
+++ b/server/server.js
@@ -2,12 +2,13 @@ var config = require('./server-config')
   , fs = require('fs')
   , url = require('url')
   , qs = require('querystring')
-  , path = require('path');
+  , path = require('path')
+  , ws_port = config.ws_port;
 
   
 //Set up WebSocket server
 const WebSocket = require('ws');
-const wss = new WebSocket.Server({port:8082});
+const wss = new WebSocket.Server({port:ws_port});
 
 //Set up standard Web server
 var server = require('http').createServer(webHandler);


### PR DESCRIPTION
Hey Charles,

I added the ws_port as a config option for the server, because it has to be set in the config for the http server as well.  Since they need to line up and 1 is set in config I think it makes it easier if they are both set somewhere.

The other one is changing the default HTTP_PORT to 80, this is because someone else at my church was trying to set it up and had issues getting it running, because he never accessed the correct port, changing this would make it easier for someone to get it up and running.