### PR TITLE
Added cueMethod option to toggle or cycle through cuelist

### DIFF
--- a/src/cueButton.vue
+++ b/src/cueButton.vue
@@ -62,7 +62,7 @@ module.exports = {
 					this.$root.sendCommand('cuelistGo ' + this.$props.cue);
 					break;
 				default:
-					console.log(`method ${this.method} is not valid`);
+					console.log(`method ${this.$props.method} is not valid`);
 			}
 			this.$data.fading = true;
 			var data = this.$data;

--- a/src/cueButton.vue
+++ b/src/cueButton.vue
@@ -39,6 +39,9 @@ module.exports = {
 		},
 		'textColor' : {
 		    default: '#333'
+		},
+		'method' : {
+			default: 'toggle'
 		}
 	},
 	data: function() {
@@ -48,7 +51,7 @@ module.exports = {
 	},
 	methods: {
 		toggleCue: function() {
-			if (this.isActive()) {
+			if (this.isActive()&&this.cueMethod()!='list') {
 				this.$root.sendCommand('cuelistRelease ' + this.$props.cue);
 			} else {
 				this.$root.sendCommand('cuelistGo ' + this.$props.cue);
@@ -68,6 +71,14 @@ module.exports = {
 				}
 			});
 			return active;
+		},
+		cueMethod: function() {
+			var method = 'toggle';
+			var props = this.$props;
+			if (this.$props.method === 'list') {
+				method = 'list';
+			}
+			return method;
 		}
 	}
 }

--- a/src/cueButton.vue
+++ b/src/cueButton.vue
@@ -51,10 +51,18 @@ module.exports = {
 	},
 	methods: {
 		toggleCue: function() {
-			if (this.isActive()&&this.cueMethod()!='list') {
-				this.$root.sendCommand('cuelistRelease ' + this.$props.cue);
-			} else {
-				this.$root.sendCommand('cuelistGo ' + this.$props.cue);
+			switch(this.$props.method){
+				case 'toggle':
+					if(this.isActive())
+					  this.$root.sendCommand('cuelistRelease ' + this.$props.cue);
+					else
+					  this.$root.sendCommand('cuelistGo ' + this.$props.cue);
+					break;
+				case 'list':
+					this.$root.sendCommand('cuelistGo ' + this.$props.cue);
+					break;
+				default:
+					console.log(`method ${this.method} is not valid`);
 			}
 			this.$data.fading = true;
 			var data = this.$data;
@@ -71,14 +79,6 @@ module.exports = {
 				}
 			});
 			return active;
-		},
-		cueMethod: function() {
-			var method = 'toggle';
-			var props = this.$props;
-			if (this.$props.method === 'list') {
-				method = 'list';
-			}
-			return method;
 		}
 	}
 }


### PR DESCRIPTION
Added cueMethod function. Default is a simple toggle. By defining the method attribute in your cue-button element in pgControls.vue and assigning value "list", triggering cue-button will send go command to MPC while cuelist is active, instead of release. default to method attribute is toggle and will behave that way if method is not defined.